### PR TITLE
fix: url with missing protocol cannot be parsed

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@ var url = require('url');
 var parse_url = function(remote_url, options) {
   if(typeof remote_url == "string")
     remote_url = url.parse(remote_url);
+
+  if (remote_url.hostname === null)
+    return parse_url('http://' + remote_url.href);
+
   return parse_host(remote_url.hostname, options);
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -35,6 +35,10 @@ describe("Main test suite", function() {
     expect(parse("http://jeanlebon.cloudfront.net", {allowPrivateTLD : true})).to.eql({ tld : 'cloudfront.net', domain : 'jeanlebon.cloudfront.net', sub : '' });
   });
 
+  it("should parse url strings without protocol", function() {
+    expect(parse("jeanlebon.notaires.fr")).to.eql({ tld : 'notaires.fr', domain : 'jeanlebon.notaires.fr', sub : '' });
+    expect(parse('google.com')).to.eql({ tld : 'com', domain : 'google.com', sub : '' });
+  });
 
   it("should test from github issues", function() {
 


### PR DESCRIPTION
The Problem is that Nodes url module wont return a valid URL object (relevant is the hostname) when parsing a string in where the protocol is missing.

Closes #7