### PR TITLE
fix: change condition for domains where domain parts are equal to tld level

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var parse_host = function(host, options) {
   if(tld_level == -1 && allowUnknownTLD)
     tld_level = 1;
 
-  if(parts.length <= tld_level || tld_level == -1)
+  if(parts.length < tld_level || tld_level == -1)
     throw new Error("Invalid TLD " + JSON.stringify({parts, tld_level, allowUnknownTLD}));
 
   return  {

--- a/test/index.js
+++ b/test/index.js
@@ -22,6 +22,8 @@ describe("Main test suite", function() {
 
     expect(parse("http://nowhere.local", {allowUnknownTLD : true})).to.eql({ tld : 'local', domain : 'nowhere.local', sub : '' });
     expect(parse(url.parse("http://nowhere.local"), {allowUnknownTLD : true})).to.eql({ tld : 'local', domain : 'nowhere.local', sub : '' });
+
+    expect(parse('http://zhitomir.ua')).to.eql({ tld : 'zhitomir.ua', domain : 'zhitomir.ua', sub : '' });
   });
 
 


### PR DESCRIPTION
Hi! Thanks for your library

Found problem for domains where tld level is equal to domain parts. 

For example, domain `zhitomir.ua` is tld level 2, and also contains 2 parts `['zhitomir', 'ua']. Right now the code is throwing an error for this case, so I changed the condition to avoid it.

