### PR TITLE
Added Typescripts types

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
 coverage
+index.d.ts
+index.test-d.ts

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ By default, unknown TLD throw an exception, you can allow them and use tld-extra
 * full code coverage
 * easy to read (10 lines)
 * easily updatable vs mozilla TLDs source list
+* TypeScript support
 
 # Maintenance
 You can update the remote hash table using `npm run update`

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,35 @@
+interface ParseOptions {
+  /**
+   * Allow parsing URLs that contain the TLDs specified under the "private" property
+   * in the effective_tld_names.json file.
+   */
+  allowPrivateTLD?: boolean;
+  /**
+   * Allow parsing URLs that contain TLDs that are not in the effective_tld_names.json file.
+   *
+   * @note This option can also be used when parsing URLs that contain IP addresses.
+   */
+  allowUnknownTLD?: boolean;
+}
+
+interface ParseResult {
+  tld: string;
+  domain: string;
+  sub: string;
+}
+
+declare function parse_url(
+  remote_url: string,
+  options?: ParseOptions
+): ParseResult;
+
+declare namespace parse_url {
+  /**
+   * Parse the hostname of a URL instead of the entire URL.
+   *
+   * @example parse_host('www.github.com') // { tld: 'com', domain: 'github.com', sub: 'www' }
+   */
+  export function parse_host(host: string, options?: ParseOptions): ParseResult;
+}
+
+export = parse_url;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,46 @@
+import parse_url, { parse_host } from ".";
+import { expectAssignable, expectError, expectType } from "tsd";
+
+interface ParseResult {
+  tld: string;
+  domain: string;
+  sub: string;
+}
+
+expectType<ParseResult>(parse_url(""));
+expectType<ParseResult>(parse_url("", {}));
+expectType<ParseResult>(parse_url("", { allowPrivateTLD: true }));
+expectType<ParseResult>(parse_url("", { allowUnknownTLD: true }));
+expectType<ParseResult>(
+  parse_url("", { allowPrivateTLD: true, allowUnknownTLD: true })
+);
+
+expectType<ParseResult>(parse_host(""));
+expectType<ParseResult>(parse_host("", {}));
+expectType<ParseResult>(parse_host("", { allowPrivateTLD: true }));
+expectType<ParseResult>(parse_host("", { allowUnknownTLD: true }));
+expectType<ParseResult>(
+  parse_host("", { allowPrivateTLD: true, allowUnknownTLD: true })
+);
+
+expectError<ParseResult>(parse_url());
+expectError<ParseResult>(parse_url({}));
+expectError<ParseResult>(parse_host());
+expectError<ParseResult>(parse_host({}));
+
+const testUrl = "https://github.com/131/node-tld/blob/master/index.js";
+const testHostname = "github.com";
+const testOptions = { allowPrivateTLD: true, allowUnknownTLD: true };
+
+interface ParseOptions {
+  allowPrivateTLD?: boolean;
+  allowUnknownTLD?: boolean;
+}
+
+expectAssignable<string>(testUrl);
+expectAssignable<string>(testHostname);
+expectAssignable<ParseOptions>(testOptions);
+expectType<ParseResult>(parse_url(testUrl));
+expectType<ParseResult>(parse_url(testUrl, testOptions));
+expectType<ParseResult>(parse_host(testHostname));
+expectType<ParseResult>(parse_host(testHostname, testOptions));

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "2.0.1",
   "description": "Extract the TLD/domain/subdomain parts of an URL/hostname against mozilla TLDs 'official' listing .",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "update": "node update.js",
-    "test": "npm run eslint && npm run cover",
+    "test": "npm run eslint && npm run cover && npm run test:typescript",
+    "test:typescript": "tsd",
     "preversion": "npm run test",
     "eslint": "eslint .",
     "checkall": "npm run eslint",
@@ -26,12 +28,12 @@
     "eslint-plugin-ivs": "^1.3.0",
     "expect.js": "^0.3.1",
     "mocha": "^3.1.2",
-    "nyc": "^15.1.0"
+    "nyc": "^15.1.0",
+    "tsd": "^0.17.0"
   },
   "directories": {
     "test": "test"
   },
-  "dependencies": {},
   "keywords": [
     "tld",
     "tlds",


### PR DESCRIPTION
Fixes #9 

I did not update the package version, but updating just the minor version to `2.1.0` is sufficient because adding types will not break any functionality. Anyone using this package in a TypeScript project would have set their own types anyways, so on `npm i` they'll keep using their own types even though they'll also pull the ones I have added.

Sorry this took so long. I completely forgot about it. Please let me know whenever the API changes and I'll update the types.

Any changes/comments, let me know.